### PR TITLE
Store the Firebase credentials JSON base64-encoded in a GitHub Secret…

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -193,7 +193,7 @@ jobs:
           command: |
             wget https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/master/docker-compose.yml -O docker-compose.yml
             docker compose down
+            FIREBASE_PROJECT_ID='${{ secrets.FIREBASE_PROJECT_ID }}' \
+            FIREBASE_CREDENTIALS_B64='${{ secrets.FIREBASE_CREDENTIALS_B64 }}' \
+            DEPLOY_HOST='${{ secrets.DEPLOY_HOST }}' \
             docker compose up -d --pull always
-        env:
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_CREDENTIALS: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - monitor-net
 
   game_manager:
+    build: ./game_manager
     image: ghcr.io/arquisoft/yovi_en2a-gamemanager:latest
     container_name: game_manager
     expose:
@@ -73,9 +74,7 @@ services:
       - REDIS_PORT=6379
       - GAMEY=gamey
       - FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
-      - GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json
-    volumes:
-      - ~/.secrets/firebase-credentials.json:/app/credentials.json:ro
+      - FIREBASE_CREDENTIALS_B64=${FIREBASE_CREDENTIALS_B64}
     depends_on:
       - redis_db
       - gamey
@@ -93,15 +92,14 @@ services:
       - redis_data:/data
 
   auth-engine:
+    build: ./userAuthentification
     image: ghcr.io/arquisoft/yovi_en2a-auth-engine:latest
     container_name: userAuthentification
     expose:
       - "4001"
     environment:
       - FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
-      - GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json
-    volumes:
-      - ~/.secrets/firebase-credentials.json:/app/credentials.json:ro
+      - FIREBASE_CREDENTIALS_B64=${FIREBASE_CREDENTIALS_B64}
     networks:
       - monitor-net
 

--- a/game_manager/Dockerfile
+++ b/game_manager/Dockerfile
@@ -22,6 +22,12 @@ RUN apt-get update && \
 
 # Copy the compiled binary from the builder stage
 COPY --from=builder /app/game_manager/target/release/game_manager .
+
+# Copy the entrypoint script that decodes Firebase credentials from env var
+COPY entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
+
 EXPOSE 5000
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./game_manager", "--mode", "server", "--port", "5000"]

--- a/game_manager/entrypoint.sh
+++ b/game_manager/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Decode the base64-encoded Firebase credentials and write them to a temp file.
+# This lets us pass the credentials as an environment variable instead of a
+# host-mounted volume, which is required for portable deployments.
+if [ -n "$FIREBASE_CREDENTIALS_B64" ]; then
+    echo "$FIREBASE_CREDENTIALS_B64" | base64 -d > /tmp/firebase-credentials.json
+    export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-credentials.json
+    echo "INFO: Firebase credentials written to /tmp/firebase-credentials.json"
+else
+    echo "WARNING: FIREBASE_CREDENTIALS_B64 is not set. Firebase will use default credentials lookup."
+fi
+
+exec "$@"

--- a/userAuthentification/Dockerfile
+++ b/userAuthentification/Dockerfile
@@ -24,8 +24,13 @@ RUN apt-get update && \
 # Copy the compiled binary from the builder stage
 COPY --from=builder /app/userAuthentification/target/release/userAuthentification .
 
+# Copy the entrypoint script that decodes Firebase credentials from env var
+COPY entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
+
 # Expose the port userAuthentification will listen on
 EXPOSE 4001
 
+ENTRYPOINT ["/entrypoint.sh"]
 # Run the userAuthentification server
 CMD ["./userAuthentification", "--mode", "server", "--port", "4001"]

--- a/userAuthentification/entrypoint.sh
+++ b/userAuthentification/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Decode the base64-encoded Firebase credentials and write them to a temp file.
+# This lets us pass the credentials as an environment variable instead of a
+# host-mounted volume, which is required for portable deployments.
+if [ -n "$FIREBASE_CREDENTIALS_B64" ]; then
+    echo "$FIREBASE_CREDENTIALS_B64" | base64 -d > /tmp/firebase-credentials.json
+    export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-credentials.json
+    echo "INFO: Firebase credentials written to /tmp/firebase-credentials.json"
+else
+    echo "WARNING: FIREBASE_CREDENTIALS_B64 is not set. Firebase will use default credentials lookup."
+fi
+
+exec "$@"


### PR DESCRIPTION
Add an entrypoint shell script to the game_manager and auth-engine services that, on container startup, decodes the base64 string back to a JSON file in a temporary path and sets the GOOGLE_APPLICATION_CREDENTIALS environment variable pointing to it. Remove the volume mounts from docker-compose.yml that hardcoded a VM-specific path, and replace them with the FIREBASE_CREDENTIALS_B64 environment variable passed down from GitHub Secrets through the deploy workflow. The Dockerfiles copy the entrypoint script into the image and set it as the container entrypoint.